### PR TITLE
Make cabal meta-data more accurate

### DIFF
--- a/hasbolt.cabal
+++ b/hasbolt.cabal
@@ -25,7 +25,7 @@ library
                      , Database.Bolt.Connection.Pipe
                      , Database.Bolt.Connection
                      , Database.Bolt.Record
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.8 && < 5
                      , bytestring
                      , text
                      , containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -64,3 +64,4 @@ extra-package-dbs: []
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+pvp-bounds: both


### PR DESCRIPTION
This improves the package meta-data's accuracy and thus
will help cabal operate properly and
will prevent future package releases on Hackage from bitrotting.

https://docs.haskellstack.org/en/stable/yaml_configuration/?highlight=pvp-bounds#pvp-bounds