### PR TITLE
[Feature] - Transactions support

### DIFF
--- a/hasbolt.cabal
+++ b/hasbolt.cabal
@@ -66,6 +66,7 @@ test-suite hasbolt-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
+  other-modules:       TransactionSpec
   build-depends:       base >= 4.8 && < 5
                      , hasbolt
                      , hspec >= 2.4.1 && < 2.8

--- a/hasbolt.cabal
+++ b/hasbolt.cabal
@@ -1,5 +1,5 @@
 name:                hasbolt
-version:             0.1.3.3
+version:             0.2.0.0
 synopsis:            Haskell driver for Neo4j 3+ (BOLT protocol)
 description:
   Haskell driver for Neo4j 3+ (BOLT protocol).
@@ -45,6 +45,7 @@ library
                      , Database.Bolt.Connection.Pipe
                      , Database.Bolt.Connection
                      , Database.Bolt.Record
+                     , Database.Bolt.Transaction
   build-depends:       base >= 4.7 && < 5
                      , bytestring >= 0.10.8.1 && < 0.11
                      , text >= 1.2.2.1 && < 1.3
@@ -55,6 +56,7 @@ library
                      , network >= 2.6.3.1 && < 3.1
                      , connection >= 0.2.8 && < 0.4
                      , data-default >= 0.7.1.1 && < 0.8
+                     , exceptions
   if impl(ghc < 8.6)
     build-depends:     contravariant >= 1.4.1 && < 1.6
   default-language:    Haskell2010

--- a/hasbolt.cabal
+++ b/hasbolt.cabal
@@ -56,7 +56,7 @@ library
                      , network >= 2.6.3.1 && < 3.1
                      , connection >= 0.2.8 && < 0.4
                      , data-default >= 0.7.1.1 && < 0.8
-                     , exceptions
+                     , exceptions >= 0.10.2 && < 0.11
   if impl(ghc < 8.6)
     build-depends:     contravariant >= 1.4.1 && < 1.6
   default-language:    Haskell2010
@@ -70,6 +70,7 @@ test-suite hasbolt-test
                      , hasbolt
                      , hspec >= 2.4.1 && < 2.8
                      , QuickCheck >= 2.9 && < 2.14
+                     , data-default >= 0.7.1.1 && < 0.8
                      , hex
                      , text
                      , containers

--- a/src/Database/Bolt.hs
+++ b/src/Database/Bolt.hs
@@ -6,7 +6,7 @@ module Database.Bolt
     , Pipe
     , BoltCfg (..)
     , BoltValue (..), Value (..), Structure (..), Record, RecordValue (..), at
-    , Node (..), Relationship (..), URelationship (..), Path (..), Cypher(..)
+    , Node (..), Relationship (..), URelationship (..), Path (..)
     ) where
 
 import           Database.Bolt.Connection hiding (query, queryP)

--- a/src/Database/Bolt.hs
+++ b/src/Database/Bolt.hs
@@ -2,6 +2,7 @@ module Database.Bolt
     ( BoltActionT
     , connect, close, reset
     , run, queryP, query, queryP_, query_
+    , transact
     , Pipe
     , BoltCfg (..)
     , BoltValue (..), Value (..), Structure (..), Record, RecordValue (..), at
@@ -12,6 +13,7 @@ import           Database.Bolt.Connection hiding (query, queryP)
 import           Database.Bolt.Connection.Pipe
 import           Database.Bolt.Connection.Type
 import           Database.Bolt.Record
+import           Database.Bolt.Transaction     (transact)
 import           Database.Bolt.Value.Instances ()
 import           Database.Bolt.Value.Structure ()
 import           Database.Bolt.Value.Type

--- a/src/Database/Bolt.hs
+++ b/src/Database/Bolt.hs
@@ -2,7 +2,7 @@ module Database.Bolt
     ( BoltActionT
     , connect, close, reset
     , run, queryP, query, queryP_, query_
-    , transact, transact_
+    , TxError, transact, transact_
     , Pipe
     , BoltCfg (..)
     , BoltValue (..), Value (..), Structure (..), Record, RecordValue (..), at
@@ -13,7 +13,7 @@ import           Database.Bolt.Connection hiding (query, queryP)
 import           Database.Bolt.Connection.Pipe
 import           Database.Bolt.Connection.Type
 import           Database.Bolt.Record
-import           Database.Bolt.Transaction     (transact, transact_)
+import           Database.Bolt.Transaction     (TxError, transact, transact_)
 import           Database.Bolt.Value.Instances ()
 import           Database.Bolt.Value.Structure ()
 import           Database.Bolt.Value.Type

--- a/src/Database/Bolt.hs
+++ b/src/Database/Bolt.hs
@@ -2,18 +2,18 @@ module Database.Bolt
     ( BoltActionT
     , connect, close, reset
     , run, queryP, query, queryP_, query_
-    , transact
+    , transact_
     , Pipe
     , BoltCfg (..)
     , BoltValue (..), Value (..), Structure (..), Record, RecordValue (..), at
-    , Node (..), Relationship (..), URelationship (..), Path (..)
+    , Node (..), Relationship (..), URelationship (..), Path (..), Cypher(..)
     ) where
 
 import           Database.Bolt.Connection hiding (query, queryP)
 import           Database.Bolt.Connection.Pipe
 import           Database.Bolt.Connection.Type
 import           Database.Bolt.Record
-import           Database.Bolt.Transaction     (transact)
+import           Database.Bolt.Transaction     (transact_)
 import           Database.Bolt.Value.Instances ()
 import           Database.Bolt.Value.Structure ()
 import           Database.Bolt.Value.Type

--- a/src/Database/Bolt.hs
+++ b/src/Database/Bolt.hs
@@ -2,7 +2,7 @@ module Database.Bolt
     ( BoltActionT
     , connect, close, reset
     , run, queryP, query, queryP_, query_
-    , transact_
+    , transact, transact_
     , Pipe
     , BoltCfg (..)
     , BoltValue (..), Value (..), Structure (..), Record, RecordValue (..), at
@@ -13,7 +13,7 @@ import           Database.Bolt.Connection hiding (query, queryP)
 import           Database.Bolt.Connection.Pipe
 import           Database.Bolt.Connection.Type
 import           Database.Bolt.Record
-import           Database.Bolt.Transaction     (transact_)
+import           Database.Bolt.Transaction     (transact, transact_)
 import           Database.Bolt.Value.Instances ()
 import           Database.Bolt.Value.Structure ()
 import           Database.Bolt.Value.Type

--- a/src/Database/Bolt/Connection.hs
+++ b/src/Database/Bolt/Connection.hs
@@ -4,7 +4,6 @@ module Database.Bolt.Connection
   , queryP, query
   , queryP', query'
   , queryP_, query_
-  , pullKeys, pullRecords, sendRequest
   ) where
 
 import           Database.Bolt.Connection.Pipe

--- a/src/Database/Bolt/Connection.hs
+++ b/src/Database/Bolt/Connection.hs
@@ -93,3 +93,8 @@ sendRequest pipe c =
        then pure status
        else do ackFailure pipe
                mkFailure status
+
+data Cypher = Cypher
+  { cypherQuery :: Text
+  , cypherParams :: Map Text Value
+  } deriving Show

--- a/src/Database/Bolt/Connection.hs
+++ b/src/Database/Bolt/Connection.hs
@@ -4,7 +4,7 @@ module Database.Bolt.Connection
   , queryP, query
   , queryP', query'
   , queryP_, query_
-  , sendRequest
+  , pullKeys, pullRecords, sendRequest
   ) where
 
 import           Database.Bolt.Connection.Pipe

--- a/src/Database/Bolt/Connection/Instances.hs
+++ b/src/Database/Bolt/Connection/Instances.hs
@@ -76,4 +76,4 @@ mkFailure ResponseFailure{..} =
   let (T code) = failMap ! "code"
       (T msg)  = failMap ! "message"
   in fail $ "code: " ++ show code ++ ", message: " ++ show msg
-mkFailure _ = fail "Unknown error"
+mkFailure r = fail $ "Unknown error. Response: " ++ show r

--- a/src/Database/Bolt/Connection/Type.hs
+++ b/src/Database/Bolt/Connection/Type.hs
@@ -45,7 +45,7 @@ data AuthToken = AuthToken { scheme      :: Text
                            , credentials :: Text
                            }
   deriving (Eq, Show)
-  
+
 data Response = ResponseSuccess { succMap   :: Map Text Value }
               | ResponseRecord  { recsList  :: [Value] }
               | ResponseIgnored { ignoreMap :: Map Text Value }
@@ -63,3 +63,8 @@ data Request = RequestInit { agent :: Text
              | RequestDiscardAll
              | RequestPullAll
   deriving (Eq, Show)
+
+data Cypher = Cypher
+  { cypherQuery :: Text
+  , cypherParams :: Map Text Value
+  } deriving Show

--- a/src/Database/Bolt/Connection/Type.hs
+++ b/src/Database/Bolt/Connection/Type.hs
@@ -63,8 +63,3 @@ data Request = RequestInit { agent :: Text
              | RequestDiscardAll
              | RequestPullAll
   deriving (Eq, Show)
-
-data Cypher = Cypher
-  { cypherQuery :: Text
-  , cypherParams :: Map Text Value
-  } deriving Show

--- a/src/Database/Bolt/Transaction.hs
+++ b/src/Database/Bolt/Transaction.hs
@@ -2,6 +2,7 @@
 
 module Database.Bolt.Transaction
   ( transact
+  , transact_
   )
 where
 
@@ -10,7 +11,9 @@ import           Database.Bolt.Connection.Type
 import           Database.Bolt.Connection       ( BoltActionT
                                                 , sendRequest
                                                 )
+import           Database.Bolt.Record
 
+import           Control.Exception              ( IOException )
 import           Control.Monad.Catch            ( Exception
                                                 , catch
                                                 , throwM
@@ -27,37 +30,43 @@ import           Data.Text                      ( Text )
 data TxError = TxError deriving Show
 instance Exception TxError
 
--- |Runs a list of cypher queries with parameters as an atomic operation
-transact :: MonadIO m => [Cypher] -> BoltActionT m ()
-transact cyphers = do
+-- |Runs a list of cypher queries with parameters as an atomic operation and returns the last output
+transact :: MonadIO m => [Cypher] -> BoltActionT m [Record]
+transact = undefined -- TODO: Implement
+
+-- |Runs a list of cypher queries with parameters as an atomic operation and discards all outputs
+transact_ :: MonadIO m => [Cypher] -> BoltActionT m ()
+transact_ cyphers = do
   pipe <- ask
-  liftIO (txBegin pipe) >>= \case
-    ResponseSuccess _ -> liftIO $ catch
-      (do
-        traverse_ (sendCypher pipe) cyphers
-        void $ txCommit pipe
-      )
-      (\TxError -> txRollback pipe)
-    _ -> ackFailure pipe
+  liftIO $ txBegin pipe
+  liftIO $ catch (traverse_ (sendCypher pipe) cyphers >> void (txCommit pipe))
+                 (\TxError -> txRollback pipe)
  where
+  handler :: IOException -> IO ()
+  handler e = print e >> throwM TxError
   sendCypher :: Pipe -> Cypher -> IO ()
-  sendCypher pipe cypher = sendRequest pipe cypher >>= \case
-    ResponseFailure _ -> throwM TxError
-    _                 -> pure () --TODO: Fetch records
+  sendCypher pipe cypher = do
+    putStrLn $ "Sending Cypher " ++ show (cypherQuery cypher)
+    catch
+      (sendRequest pipe cypher >>= \case
+        ResponseFailure _ -> putStrLn "Failure " >> throwM TxError
+        _                 -> discardAll pipe
+      )
+      handler
 
 txCommand :: Text -> Pipe -> IO Response
 txCommand cmd pipe = do
+  putStrLn $ "Sending command " ++ show cmd
   flush pipe $ RequestRun cmd empty
+  void $ fetch pipe
+  flush pipe RequestPullAll
   fetch pipe
 
-txCommit :: Pipe -> IO Response
-txCommit = txCommand "COMMIT"
+txBegin :: Pipe -> IO ()
+txBegin = void . txCommand "BEGIN"
 
-txBegin :: Pipe -> IO Response
-txBegin = txCommand "BEGIN"
+txCommit :: Pipe -> IO ()
+txCommit = void . txCommand "COMMIT"
 
 txRollback :: Pipe -> IO ()
-txRollback pipe = do
-  flush pipe RequestAckFailure
-  void $ fetch pipe
-  void $ txCommand "ROLLBACK" pipe
+txRollback = void . txCommand "ROLLBACK"

--- a/src/Database/Bolt/Transaction.hs
+++ b/src/Database/Bolt/Transaction.hs
@@ -56,13 +56,11 @@ transaction discard cyphers = do
   txQuery :: Text -> Map Text Value -> BoltActionT IO [Record]
   txQuery q p = if discard then [] <$ queryP_ q p else queryP' q p
   sendCypher :: Pipe -> Cypher -> IO [Record]
-  sendCypher pipe c = do
-    putStrLn $ "Sending Cypher " ++ show (cypherQuery c)
+  sendCypher pipe c =
     catch (run pipe $ txQuery (cypherQuery c) (cypherParams c)) handler
 
 txCommand :: Text -> Pipe -> IO Response
 txCommand cmd pipe = do
-  putStrLn $ "Sending command " ++ show cmd
   flush pipe $ RequestRun cmd empty
   void $ fetch pipe
   flush pipe RequestPullAll

--- a/src/Database/Bolt/Transaction.hs
+++ b/src/Database/Bolt/Transaction.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE LambdaCase, OverloadedStrings #-}
+
+module Database.Bolt.Transaction
+  ( transact
+  )
+where
+
+import           Database.Bolt.Connection.Pipe
+import           Database.Bolt.Connection.Type
+import           Database.Bolt.Connection       ( BoltActionT
+                                                , sendRequest
+                                                )
+
+import           Control.Monad.Catch            ( Exception
+                                                , catch
+                                                , throwM
+                                                )
+import           Control.Monad.IO.Class         ( MonadIO(..)
+                                                , liftIO
+                                                )
+import           Control.Monad.Trans.Reader     ( ask )
+import           Data.Foldable                  ( traverse_ )
+import           Data.Functor                   ( void )
+import           Data.Map.Strict                ( empty )
+import           Data.Text                      ( Text )
+
+data TxError = TxError deriving Show
+instance Exception TxError
+
+-- |Runs a list of cypher queries with parameters as an atomic operation
+transact :: MonadIO m => [Cypher] -> BoltActionT m ()
+transact cyphers = do
+  pipe <- ask
+  liftIO (txBegin pipe) >>= \case
+    ResponseSuccess _ -> liftIO $ catch
+      (do
+        traverse_ (sendCypher pipe) cyphers
+        void $ txCommit pipe
+      )
+      (\TxError -> txRollback pipe)
+    _ -> ackFailure pipe
+ where
+  sendCypher :: Pipe -> Cypher -> IO ()
+  sendCypher pipe cypher = sendRequest pipe cypher >>= \case
+    ResponseFailure _ -> throwM TxError
+    _                 -> pure () --TODO: Fetch records
+
+txCommand :: Text -> Pipe -> IO Response
+txCommand cmd pipe = do
+  flush pipe $ RequestRun cmd empty
+  fetch pipe
+
+txCommit :: Pipe -> IO Response
+txCommit = txCommand "COMMIT"
+
+txBegin :: Pipe -> IO Response
+txBegin = txCommand "BEGIN"
+
+txRollback :: Pipe -> IO ()
+txRollback pipe = do
+  flush pipe RequestAckFailure
+  void $ fetch pipe
+  void $ txCommand "ROLLBACK" pipe

--- a/src/Database/Bolt/Transaction.hs
+++ b/src/Database/Bolt/Transaction.hs
@@ -10,12 +10,9 @@ where
 import           Database.Bolt.Connection.Pipe
 import           Database.Bolt.Connection.Type
 import           Database.Bolt.Connection       ( BoltActionT
-                                                , queryP_
-                                                , queryP'
                                                 , run
                                                 )
 import           Database.Bolt.Record
-import           Database.Bolt.Value.Type
 
 import           Control.Exception              ( IOException )
 import           Control.Monad                  ( join )
@@ -28,36 +25,27 @@ import           Control.Monad.IO.Class         ( MonadIO(..)
                                                 )
 import           Control.Monad.Trans.Reader     ( ask )
 import           Data.Functor                   ( void )
-import           Data.Map                       ( Map )
 import           Data.Map.Strict                ( empty )
 import           Data.Text                      ( Text )
 
 data TxError = TxError deriving Show
 instance Exception TxError
 
--- |Runs a list of cypher queries with parameters as an atomic operation and returns all the records
-transact :: MonadIO m => [Cypher] -> BoltActionT m [Record]
-transact = transaction False
-
--- |Runs a list of cypher queries with parameters as an atomic operation and discards all outputs
-transact_ :: MonadIO m => [Cypher] -> BoltActionT m ()
-transact_ = void . transaction True
-
-transaction :: MonadIO m => Bool -> [Cypher] -> BoltActionT m [Record]
-transaction discard cyphers = do
+-- |Runs a list of 'BoltActionT' as an atomic operation and returns all the records or throws 'TxError' if something went wrong
+transact :: [BoltActionT IO [Record]] -> BoltActionT IO [Record]
+transact actions = do
   pipe <- ask
   liftIO $ txBegin pipe
   liftIO $ catch
-    (join <$> traverse (sendCypher pipe) cyphers <* void (txCommit pipe))
-    (\TxError -> txRollback pipe >> throwM TxError)
+    (join <$> traverse (run pipe) actions <* void (txCommit pipe))
+    (handler pipe)
  where
-  handler :: IOException -> IO [Record]
-  handler e = print e >> throwM TxError
-  txQuery :: Text -> Map Text Value -> BoltActionT IO [Record]
-  txQuery q p = if discard then [] <$ queryP_ q p else queryP' q p
-  sendCypher :: Pipe -> Cypher -> IO [Record]
-  sendCypher pipe c =
-    catch (run pipe $ txQuery (cypherQuery c) (cypherParams c)) handler
+  handler :: Pipe -> IOException -> IO [Record]
+  handler pipe _ = txRollback pipe >> throwM TxError
+
+-- |Runs a list of 'BoltActionT' as an atomic operation and discards all outputs or throws 'TxError' if something went wrong
+transact_ :: [BoltActionT IO [Record]] -> BoltActionT IO ()
+transact_ = void . transact
 
 txCommand :: Text -> Pipe -> IO Response
 txCommand cmd pipe = do

--- a/src/Database/Bolt/Transaction.hs
+++ b/src/Database/Bolt/Transaction.hs
@@ -10,10 +10,12 @@ where
 import           Database.Bolt.Connection.Pipe
 import           Database.Bolt.Connection.Type
 import           Database.Bolt.Connection       ( BoltActionT
+                                                , queryP_
                                                 , queryP'
                                                 , run
                                                 )
 import           Database.Bolt.Record
+import           Database.Bolt.Value.Type
 
 import           Control.Exception              ( IOException )
 import           Control.Monad                  ( join )
@@ -26,6 +28,7 @@ import           Control.Monad.IO.Class         ( MonadIO(..)
                                                 )
 import           Control.Monad.Trans.Reader     ( ask )
 import           Data.Functor                   ( void )
+import           Data.Map                       ( Map )
 import           Data.Map.Strict                ( empty )
 import           Data.Text                      ( Text )
 
@@ -34,22 +37,28 @@ instance Exception TxError
 
 -- |Runs a list of cypher queries with parameters as an atomic operation and returns all the records
 transact :: MonadIO m => [Cypher] -> BoltActionT m [Record]
-transact cyphers = do
-  pipe <- ask
-  liftIO $ txBegin pipe
-  liftIO $ catch (join <$> traverse (sendCypher pipe) cyphers <* void (txCommit pipe))
-                 (\TxError -> txRollback pipe >> throwM TxError)
- where
-  handler :: IOException -> IO [Record]
-  handler e = print e >> throwM TxError
-  sendCypher :: Pipe -> Cypher -> IO [Record]
-  sendCypher pipe c = do
-    putStrLn $ "Sending Cypher " ++ show (cypherQuery c)
-    catch (run pipe $ queryP' (cypherQuery c) (cypherParams c)) handler
+transact = transaction False
 
 -- |Runs a list of cypher queries with parameters as an atomic operation and discards all outputs
 transact_ :: MonadIO m => [Cypher] -> BoltActionT m ()
-transact_ = void . transact
+transact_ = void . transaction True
+
+transaction :: MonadIO m => Bool -> [Cypher] -> BoltActionT m [Record]
+transaction discard cyphers = do
+  pipe <- ask
+  liftIO $ txBegin pipe
+  liftIO $ catch
+    (join <$> traverse (sendCypher pipe) cyphers <* void (txCommit pipe))
+    (\TxError -> txRollback pipe >> throwM TxError)
+ where
+  handler :: IOException -> IO [Record]
+  handler e = print e >> throwM TxError
+  txQuery :: Text -> Map Text Value -> BoltActionT IO [Record]
+  txQuery q p = if discard then [] <$ queryP_ q p else queryP' q p
+  sendCypher :: Pipe -> Cypher -> IO [Record]
+  sendCypher pipe c = do
+    putStrLn $ "Sending Cypher " ++ show (cypherQuery c)
+    catch (run pipe $ txQuery (cypherQuery c) (cypherParams c)) handler
 
 txCommand :: Text -> Pipe -> IO Response
 txCommand cmd pipe = do

--- a/src/Database/Bolt/Transaction.hs
+++ b/src/Database/Bolt/Transaction.hs
@@ -10,8 +10,8 @@ where
 import           Database.Bolt.Connection.Pipe
 import           Database.Bolt.Connection.Type
 import           Database.Bolt.Connection       ( BoltActionT
-                                                , pullKeys
-                                                , pullRecords
+                                                , queryP'
+                                                , run
                                                 )
 import           Database.Bolt.Record
 
@@ -43,9 +43,9 @@ transact cyphers = do
   handler :: IOException -> IO [Record]
   handler e = print e >> throwM TxError
   sendCypher :: Pipe -> Cypher -> IO [Record]
-  sendCypher pipe cypher = do
-    putStrLn $ "Sending Cypher " ++ show (cypherQuery cypher)
-    catch (pullKeys pipe cypher >>= pullRecords True pipe) handler
+  sendCypher pipe c = do
+    putStrLn $ "Sending Cypher " ++ show (cypherQuery c)
+    catch (run pipe $ queryP' (cypherQuery c) (cypherParams c)) handler
 
 -- |Runs a list of cypher queries with parameters as an atomic operation and discards all outputs
 transact_ :: MonadIO m => [Cypher] -> BoltActionT m ()

--- a/src/Database/Bolt/Transaction.hs
+++ b/src/Database/Bolt/Transaction.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Database.Bolt.Transaction
-  ( transact
+  ( TxError
+  , transact
   , transact_
   )
 where
@@ -37,7 +38,7 @@ transact cyphers = do
   pipe <- ask
   liftIO $ txBegin pipe
   liftIO $ catch (join <$> traverse (sendCypher pipe) cyphers <* void (txCommit pipe))
-                 (\TxError -> [] <$ txRollback pipe)
+                 (\TxError -> txRollback pipe >> throwM TxError)
  where
   handler :: IOException -> IO [Record]
   handler e = print e >> throwM TxError

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,8 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  - exceptions-0.10.2@sha256:de2be08eb73e1fb4115135c62f5d5f7ed9bdb9affff318687ac6cc0438b497f0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,45 +10,14 @@ import           Data.Text                (Text)
 import qualified Data.Text                as T (pack)
 import           Test.Hspec
 
-import           Data.Default           (Default (..))
 import           Database.Bolt
+import           TransactionSpec          (transactionTests)
 
 main :: IO ()
 main = hspec $ do
          packStreamTests
          unpackStreamTests
          --transactionTests  -- Requires Neo4j running
-
-cyphers :: [Cypher]
-cyphers =
-  [ Cypher "CREATE (p:Person { name: 'Simon', age: 61 } ) RETURN p"  M.empty
-  , Cypher "CREATE (p:Person { name: 'Philip', age: 63 } ) RETURN p" M.empty
-  , Cypher "CREATE (p:Person { name: 'Erik', age: 56 } ) RETURN p"   M.empty
-  ]
-
-failedCyphers :: [Cypher]
-failedCyphers =
-  [ Cypher "CREATE (g:Guitar { brand: 'Gibson' } ) RETURN g"  M.empty
-  , Cypher "CREATE (g:Guitar { brand: 'Fender' } ) RETURN g"  M.empty
-  , Cypher "CREATE (g:Guitar { brand: 'Ibanez' } ) RETURN g"  M.empty
-  , Cypher "This is going to make it fail, BOOM!"  M.empty
-  , Cypher "CREATE (g:Guitar { brand: 'Schecter' } ) RETURN g"  M.empty
-  ]
-
-mkConnection :: IO Pipe
-mkConnection = connect $ def { user = "neo4j", password = "test" }
-
-transactionTests :: Spec
-transactionTests =
-  describe "Transaction" $ do
-    it "commits" $ do
-      pipe <- mkConnection
-      run pipe $ transact cyphers :: IO [Record]
-      close pipe
-    it "rollsback due to malformed cypher query" $ do
-      pipe <- mkConnection
-      run pipe $ transact failedCyphers :: IO [Record]
-      close pipe
 
 unpackStreamTests :: Spec
 unpackStreamTests =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,12 +4,11 @@ import           Control.Applicative      ((<$>))
 import           Data.ByteString          (ByteString)
 import           Data.ByteString.Lazy     (fromStrict, toStrict)
 import           Data.Hex
-import           Data.Map                 (Map (..))
+import           Data.Map                 (Map)
 import qualified Data.Map                 as M (empty, fromList)
 import           Data.Text                (Text)
 import qualified Data.Text                as T (pack)
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Default           (Default (..))
 import           Database.Bolt
@@ -44,11 +43,11 @@ transactionTests =
   describe "Transaction" $ do
     it "commits" $ do
       pipe <- mkConnection
-      run pipe $ transact_ cyphers :: IO ()
+      run pipe $ transact cyphers :: IO [Record]
       close pipe
-    it "rollsback due to malformed query" $ do
+    it "rollsback due to malformed cypher query" $ do
       pipe <- mkConnection
-      run pipe $ transact_ failedCyphers :: IO ()
+      run pipe $ transact failedCyphers :: IO [Record]
       close pipe
 
 unpackStreamTests :: Spec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,12 +11,45 @@ import qualified Data.Text                as T (pack)
 import           Test.Hspec
 import           Test.QuickCheck
 
-import Database.Bolt
+import           Data.Default           (Default (..))
+import           Database.Bolt
 
 main :: IO ()
 main = hspec $ do
          packStreamTests
          unpackStreamTests
+         --transactionTests  -- Requires Neo4j running
+
+cyphers :: [Cypher]
+cyphers =
+  [ Cypher "CREATE (p:Person { name: 'Simon', age: 61 } ) RETURN p"  M.empty
+  , Cypher "CREATE (p:Person { name: 'Philip', age: 63 } ) RETURN p" M.empty
+  , Cypher "CREATE (p:Person { name: 'Erik', age: 56 } ) RETURN p"   M.empty
+  ]
+
+failedCyphers :: [Cypher]
+failedCyphers =
+  [ Cypher "CREATE (g:Guitar { brand: 'Gibson' } ) RETURN g"  M.empty
+  , Cypher "CREATE (g:Guitar { brand: 'Fender' } ) RETURN g"  M.empty
+  , Cypher "CREATE (g:Guitar { brand: 'Ibanez' } ) RETURN g"  M.empty
+  , Cypher "This is going to make it fail, BOOM!"  M.empty
+  , Cypher "CREATE (g:Guitar { brand: 'Schecter' } ) RETURN g"  M.empty
+  ]
+
+mkConnection :: IO Pipe
+mkConnection = connect $ def { user = "neo4j", password = "test" }
+
+transactionTests :: Spec
+transactionTests =
+  describe "Transaction" $ do
+    it "commits" $ do
+      pipe <- mkConnection
+      run pipe $ transact_ cyphers :: IO ()
+      close pipe
+    it "rollsback due to malformed query" $ do
+      pipe <- mkConnection
+      run pipe $ transact_ failedCyphers :: IO ()
+      close pipe
 
 unpackStreamTests :: Spec
 unpackStreamTests =

--- a/test/TransactionSpec.hs
+++ b/test/TransactionSpec.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module TransactionSpec
+  ( transactionTests
+  )
+where
+
+import           Data.Map                       ( Map )
+import qualified Data.Map                      as M
+import           Data.Maybe                     ( maybeToList )
+import           Data.Monoid                    ( (<>) )
+import           Data.Text                      ( Text
+                                                , pack
+                                                )
+import           Test.Hspec
+
+import           Data.Default                   ( Default(..) )
+import           Database.Bolt           hiding ( pack )
+
+mkConnection :: IO Pipe
+mkConnection = connect $ def { user = "neo4j", password = "test" }
+
+anyTxError :: Selector TxError
+anyTxError = const True
+
+transactionTests :: Spec
+transactionTests = describe "Transaction" $ do
+  it "commits" $ do
+    pipe    <- mkConnection
+    persons <- toEntityList "p" <$> run pipe (transact cyphers) :: IO [Person]
+    close pipe
+    persons `shouldBe` input
+  it "rollsback due to malformed cypher query" $ do
+    pipe    <- mkConnection
+    let stmt = toEntityList "g" <$> run pipe (transact failedCyphers) :: IO [Guitar]
+    stmt `shouldThrow` anyTxError
+    close pipe
+
+-- Test input data
+
+input :: [Person]
+input = [Person "Simon" 61, Person "Philip" 63, Person "Erik" 56]
+
+cyphers :: [Cypher]
+cyphers = toCypher <$> input where
+  toCypher p = Cypher
+    (  "CREATE (p:Person { name: '"
+    <> name p
+    <> "', age: "
+    <> pack (show $ age p)
+    <> " } ) RETURN p"
+    )
+    M.empty
+
+failedCyphers :: [Cypher]
+failedCyphers =
+  [ Cypher "CREATE (g:Guitar { brand: 'Gibson' } ) RETURN g"   M.empty
+  , Cypher "CREATE (g:Guitar { brand: 'Fender' } ) RETURN g"   M.empty
+  , Cypher "CREATE (g:Guitar { brand: 'Ibanez' } ) RETURN g"   M.empty
+  , Cypher "This is going to make it fail, BOOM!"              M.empty
+  , Cypher "CREATE (g:Guitar { brand: 'Schecter' } ) RETURN g" M.empty
+  ]
+
+-- Record parser helpers
+
+type NodeProps = Map Text Value
+
+class NodeMapper a where
+  toEntity :: NodeProps -> Maybe a
+
+toNode :: Monad m => Text -> Record -> m Node
+toNode identifier record = record `at` identifier >>= exact
+
+toNodeProps :: Monad m => Text -> Record -> m NodeProps
+toNodeProps identifier r = nodeProps <$> toNode identifier r
+
+toEntityList :: NodeMapper a => Text -> [Record] -> [a]
+toEntityList identifier records = records >>= maybeToList . f
+  where f r = (toNodeProps identifier r :: Maybe NodeProps) >>= toEntity
+
+newtype Guitar = Guitar { brand :: Text } deriving (Eq, Show)
+
+data Person = Person
+  { name :: Text
+  , age :: Int
+  } deriving (Eq, Show)
+
+instance NodeMapper Guitar where
+  toEntity p = Guitar <$> (M.lookup "brand" p >>= exact :: Maybe Text)
+
+instance NodeMapper Person where
+  toEntity p =
+    Person
+      <$> (M.lookup "name" p >>= exact :: Maybe Text)
+      <*> (M.lookup "age" p >>= exact :: Maybe Int)


### PR DESCRIPTION
closes #14 

Hi @zmactep, try it out and let me know what you think. Before merging I should:

- ~Remove all the `putStrLn` / `print` lines I added for debugging purposes.~ DONE
- ~Implement `transact` that collects the records of the last cypher query or all the queries?~ DONE

Here's the output of the `Spec` (including the debugging lines):

```
Transaction
Sending command "BEGIN"
Sending Cypher "CREATE (p:Person { name: 'Simon', age: 61 } ) RETURN p"
Sending Cypher "CREATE (p:Person { name: 'Philip', age: 63 } ) RETURN p"
Sending Cypher "CREATE (p:Person { name: 'Erik', age: 56 } ) RETURN p"
Sending command "COMMIT"
  commits
Sending command "BEGIN"
Sending Cypher "CREATE (g:Guitar { brand: 'Gibson' } ) RETURN g"
Sending Cypher "CREATE (g:Guitar { brand: 'Fender' } ) RETURN g"
Sending Cypher "CREATE (g:Guitar { brand: 'Ibanez' } ) RETURN g"
Sending Cypher "This is going to make it fail, BOOM!"
user error (code: "Neo.ClientError.Statement.SyntaxError", message: "Invalid input 'T': expected <init> (line 1, column 1 (offset: 0))\n\"This is going to make it fail, BOOM!\"\n ^")
Starting ROLLBACK
Sending command "ROLLBACK"
  rollsback due to a malformed query
```

---

In another PR I would like to setup the CI Build to have a running instance of Neo4j so we can test cypher queries against it, including the transactions. What do you think?