### PR TITLE
version 0.1.7.0: better bolt v3 support

### DIFF
--- a/hasbolt.cabal
+++ b/hasbolt.cabal
@@ -1,5 +1,5 @@
 name:                hasbolt
-version:             0.1.6.3
+version:             0.1.7.0
 synopsis:            Haskell driver for Neo4j 3+ (BOLT protocol)
 description:
   Haskell driver for Neo4j 3+ (BOLT protocol).

--- a/src/Database/Bolt/Connection/Type.hs
+++ b/src/Database/Bolt/Connection/Type.hs
@@ -122,24 +122,35 @@ data AuthToken = AuthToken { scheme      :: Text
 
 data Response = ResponseSuccess { succMap   :: Map Text Value }
               | ResponseRecord  { recsList  :: [Value] }
-              | ResponseIgnored { ignoreMap :: Map Text Value }
+              | ResponseIgnored
               | ResponseFailure { failMap   :: Map Text Value }
   deriving (Eq, Show)
 
-data Request = RequestInit  { agent   :: Text
-                            , token   :: AuthToken
-                            , isHello :: Bool
-                            }
-             | RequestRun   { statement  :: Text
-                            , parameters :: Map Text Value
-                            }
-             | RequestRunV3 { statement  :: Text
-                            , parameters :: Map Text Value
-                            , extra      :: Map Text Value
-                            }
+data Request = RequestInit
+                 { agent   :: Text
+                 , token   :: AuthToken
+                 , isHello :: Bool
+                 }
+             | RequestRun
+                 { statement  :: Text
+                 , parameters :: Map Text Value
+                 }
+             | RequestRunV3
+                 { statement  :: Text
+                 , parameters :: Map Text Value
+                 , extra      :: Map Text Value
+                 }
              | RequestAckFailure
              | RequestReset
              | RequestDiscardAll
              | RequestPullAll
              | RequestGoodbye
+               -- | Introduced in v3.
+             | RequestBegin
+                 { extra       :: Map Text Value
+                 }
+               -- | Introduced in v3.
+             | RequestCommit
+               -- | Introduced in v3.
+             | RequestRollback
   deriving (Eq, Show)

--- a/src/Database/Bolt/Value/Helpers.hs
+++ b/src/Database/Bolt/Value/Helpers.hs
@@ -160,27 +160,47 @@ sigPath :: Word8
 sigPath = 80
 
 -- == BOLT requests signatures
+-- https://neo4j.com/docs/bolt/current/bolt/message/
 
+-- @INIT@ in v1 & v2, @HELLO@ in v3.
 sigInit :: Word8
-sigInit = 1
+sigInit = 0x01
 
+-- @RUN@.
 sigRun :: Word8
-sigRun = 16
+sigRun = 0x10
 
+-- @ACK_FAILURE@, removed in v3.
 sigAFail :: Word8
-sigAFail = 14
+sigAFail = 0x0e
 
+-- @RESET@
 sigReset :: Word8
-sigReset = 15
+sigReset = 0x0f
 
+-- @DISCARD_ALL@ in v1 & v2, @DISCARD@ in v3.
 sigDAll :: Word8
-sigDAll = 47
+sigDAll = 0x2f
 
+-- @PULL_ALL@ in v1 & v2, @PULL@ in v3.
 sigPAll :: Word8
-sigPAll = 63
+sigPAll = 0x3f
 
-sigGBye :: Word8 
-sigGBye = 2
+-- @GOODBYE@, introduced in v3.
+sigGBye :: Word8
+sigGBye = 0x02
+
+-- @BEGIN@, introduced in v3.
+sigBegin :: Word8
+sigBegin = 0x11
+
+-- @COMMIT@, introduced in v3.
+sigCommit :: Word8
+sigCommit = 0x12
+
+-- @ROLLBACK@, introduced in v3.
+sigRollback :: Word8
+sigRollback = 0x13
 
 -- == BOLT responses signatures
 

--- a/src/Database/Bolt/Value/Type.hs
+++ b/src/Database/Bolt/Value/Type.hs
@@ -65,7 +65,7 @@ data Structure = Structure { signature :: Word8
 
 -- |Generalizes all datatypes that can be deserialized from 'Structure's.
 class FromStructure a where
-  fromStructure :: MonadError UnpackError m => Structure -> m a
+  fromStructure :: (HasCallStack, MonadError UnpackError m) => Structure -> m a
 
 -- |Generalizes all datatypes that can be serialized to 'Structure's.
 class ToStructure a where


### PR DESCRIPTION
In bolt v3 transactions are not Cypher commands "begin" / "commit" / "rollback", but new types of bolt messages.

Also fixed ResponseIgnored, according to spec it does not have any arguments and never did, but our parser expected. Probably we never actually received that response in bolt v1.